### PR TITLE
LevelZero fixes

### DIFF
--- a/include/vendors/lz_wrapper.hpp
+++ b/include/vendors/lz_wrapper.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ze_api.h>
-#include <zes_api.h>
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
 
 #include <array>
 

--- a/include/vendors/lz_wrapper.hpp
+++ b/include/vendors/lz_wrapper.hpp
@@ -165,7 +165,7 @@ private:
     }
   
     devices.resize(devices_count);
-    for (unsigned i = 0, offset = 0; i < devices_count; i++) {
+    for (unsigned i = 0, offset = 0; i < drivers.size(); i++) {
       zeDeviceGet(drivers[i], &tmp, &devices.data()[offset]);
       offset += tmp;
     }


### PR DESCRIPTION
- On a system with multiple GPUs, the initialization would crash due to wrong loop condition.
- At least on Ubuntu and on Intel Dev Cloud, the CMake module returns include path without the last `level_zero` directory, so it has to be added to the `#include` directive.