### PR TITLE
Support for single frequency change

### DIFF
--- a/include/queue.hpp
+++ b/include/queue.hpp
@@ -69,7 +69,8 @@ public:
       event = sycl::queue::submit(
           [&](sycl::handler& h) {
             try {
-              device.set_all_frequencies(core_target_frequency, uncore_target_frequency);
+              if (core_target_frequency) device.set_core_frequency(core_target_frequency);
+              if (uncore_target_frequency) device.set_uncore_frequency(uncore_target_frequency);
             } catch (const std::exception& e) {
               std::cerr << e.what() << '\n';
             }
@@ -101,7 +102,8 @@ public:
     sycl::event event = sycl::queue::submit(
         [&](sycl::handler& h) {
           try {
-            device.set_all_frequencies(kernel_core_frequency, kernel_uncore_frequency);
+            if (kernel_core_frequency) device.set_core_frequency(kernel_core_frequency);
+            if (kernel_uncore_frequency) device.set_uncore_frequency(kernel_uncore_frequency);
           } catch (const std::exception& e) {
             std::cerr << e.what() << '\n';
           }
@@ -161,7 +163,7 @@ private:
   std::shared_ptr<detail::profiling_manager> profiling;
 #endif
 
-  inline bool has_target() { return core_target_frequency != 0 && uncore_target_frequency != 0; }
+  inline bool has_target() { return core_target_frequency != 0 || uncore_target_frequency != 0; }
 
   template <typename... Args>
   static sycl::queue check_args(Args&&... args) {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(matrix_mul matrix_mul/matrix_mul.cpp)
 add_executable(query_freq query_freq/query_freq.cpp)
 add_executable(saxpy saxpy/saxpy.cpp)
 add_executable(concurrent_matmul concurrent_matmul/concurrent_matmul.cpp)
+add_executable(freq_scale freq_scale/freq_scale.cpp)
 
 get_directory_property(all_targets BUILDSYSTEM_TARGETS)
 

--- a/samples/freq_scale/freq_scale.cpp
+++ b/samples/freq_scale/freq_scale.cpp
@@ -33,12 +33,12 @@ int main(int argc, char **argv) {
   sycl::buffer<int, 1> buf1{a.data(), N};
   sycl::buffer<int, 1> buf2{b.data(), N};
 
-  // q1.submit([&](sycl::handler &h) {
-  //   sycl::accessor acc {buf1, h, sycl::read_write};
-  //   h.parallel_for(sycl::range<1>{N}, [=](auto id) {
-  //     acc[id] *= acc[id] * VAL;
-  //   });
-  // }).wait();
+  q1.submit([&](sycl::handler &h) {
+    sycl::accessor acc {buf1, h, sycl::read_write};
+    h.parallel_for(sycl::range<1>{N}, [=](auto id) {
+      acc[id] *= acc[id] * VAL;
+    });
+  }).wait();
 
   q2.submit(mem_freq, core_freq, [&](sycl::handler &h) {
     sycl::accessor acc {buf2, h, sycl::read_write};

--- a/samples/freq_scale/freq_scale.cpp
+++ b/samples/freq_scale/freq_scale.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <synergy.hpp>
+
+constexpr int N = 1024;
+constexpr int VAL = 2;
+
+void print_usage() {
+  std::cout << "Usage: ./freq_scale <memory_frequency> <core_frequency>" << std::endl;
+}
+
+int main(int argc, char **argv) {
+
+  if (argc < 3) {
+    print_usage();
+    return 1;
+  }
+
+  synergy::frequency mem_freq, core_freq;
+  try {
+    mem_freq = atoi(argv[1]);
+    core_freq = atoi(argv[2]);
+  } catch (std::exception &e) {
+    print_usage();
+    return 1;
+  }
+
+  synergy::queue q1 { mem_freq, core_freq, sycl::gpu_selector_v };
+  synergy::queue q2 { sycl::gpu_selector_v };
+
+  std::vector<int> a(N, 2);
+  std::vector<int> b(N, 3);
+
+  sycl::buffer<int, 1> buf1{a.data(), N};
+  sycl::buffer<int, 1> buf2{b.data(), N};
+
+  // q1.submit([&](sycl::handler &h) {
+  //   sycl::accessor acc {buf1, h, sycl::read_write};
+  //   h.parallel_for(sycl::range<1>{N}, [=](auto id) {
+  //     acc[id] *= acc[id] * VAL;
+  //   });
+  // }).wait();
+
+  q2.submit(mem_freq, core_freq, [&](sycl::handler &h) {
+    sycl::accessor acc {buf2, h, sycl::read_write};
+    h.parallel_for(sycl::range<1>{N}, [=](sycl::item<1> id) {
+      acc[id[0]] *= acc[id[0]] * VAL;
+    });
+  }).wait();
+}


### PR DESCRIPTION
In ***queue.hpp*** the `has_target()` method returns true if and only if both core and uncore frequency is not equals to 0.

Now the frequency change happens also if one of the two frequencies is not equal to 0.

This prevents to change frequency also in system in which is not supported the memory frequency scaling. 